### PR TITLE
Fix/refactor recycler view implementations

### DIFF
--- a/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceListActivity.java
+++ b/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceListActivity.java
@@ -127,13 +127,14 @@ public class ConferenceListActivity extends InjectableActionBarActivity implemen
             return getItem(position).getId();
         }
 
-        public class ViewHolder extends RecyclerView.ViewHolder {
+        public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
             @InjectView(R.id.name) public TextView nameView;
             private ConferenceData conferenceData;
 
             public ViewHolder(View view) {
                 super(view);
                 ButterKnife.inject(this, view);
+                view.setOnClickListener(this);
             }
 
             public void setName(String name) {
@@ -143,14 +144,11 @@ public class ConferenceListActivity extends InjectableActionBarActivity implemen
             public void setConferenceData(ConferenceData conferenceData) {
                 this.conferenceData = conferenceData;
                 setName(conferenceData.getName());
+            }
 
-                final long conferenceId = conferenceData.getId();
-                itemView.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View view) {
-                        launchConferenceSessionsListActivity(conferenceId);
-                    }
-                });
+            @Override
+            public void onClick(View v) {
+                launchConferenceSessionsListActivity(conferenceData.getId());
             }
         }
     }

--- a/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceListActivity.java
+++ b/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceListActivity.java
@@ -94,19 +94,6 @@ public class ConferenceListActivity extends InjectableActionBarActivity implemen
 
         List<ConferenceData> conferenceDatas;
 
-        public class ViewHolder extends RecyclerView.ViewHolder {
-            @InjectView(R.id.name) public TextView nameView;
-
-            public ViewHolder(View view) {
-                super(view);
-                ButterKnife.inject(this, view);
-            }
-
-            public void setName(String name) {
-                nameView.setText(name);
-            }
-        }
-
         public ConferencesAdapter(List<ConferenceData> conferenceDatas) {
             this.conferenceDatas = conferenceDatas;
         }
@@ -127,15 +114,7 @@ public class ConferenceListActivity extends InjectableActionBarActivity implemen
 
         @Override
         public void onBindViewHolder(ConferencesAdapter.ViewHolder holder, int position) {
-            holder.setName(getItem(position).getName());
-
-            final long conferenceId = getItemId(position);
-            holder.itemView.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    launchConferenceSessionsListActivity(conferenceId);
-                }
-            });
+            holder.setConferenceData(getItem(position));
         }
 
         @Override
@@ -146,6 +125,33 @@ public class ConferenceListActivity extends InjectableActionBarActivity implemen
         @Override
         public long getItemId(int position) {
             return getItem(position).getId();
+        }
+
+        public class ViewHolder extends RecyclerView.ViewHolder {
+            @InjectView(R.id.name) public TextView nameView;
+            private ConferenceData conferenceData;
+
+            public ViewHolder(View view) {
+                super(view);
+                ButterKnife.inject(this, view);
+            }
+
+            public void setName(String name) {
+                nameView.setText(name);
+            }
+
+            public void setConferenceData(ConferenceData conferenceData) {
+                this.conferenceData = conferenceData;
+                setName(conferenceData.getName());
+
+                final long conferenceId = conferenceData.getId();
+                itemView.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        launchConferenceSessionsListActivity(conferenceId);
+                    }
+                });
+            }
         }
     }
 }

--- a/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceSessionListActivity.java
+++ b/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceSessionListActivity.java
@@ -124,7 +124,7 @@ public class ConferenceSessionListActivity extends InjectableActionBarActivity i
             return conferenceSessions.get(position);
         }
 
-        public class ViewHolder extends RecyclerView.ViewHolder {
+        public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
             private final SimpleDateFormat DAY_FORMATTER = new SimpleDateFormat("EEEE, MMMM dd, yyyy", Locale.US);
             private final SimpleDateFormat TIME_FORMATTER = new SimpleDateFormat("h:mm a", Locale.US);
 
@@ -138,6 +138,7 @@ public class ConferenceSessionListActivity extends InjectableActionBarActivity i
             public ViewHolder(View v) {
                 super(v);
                 ButterKnife.inject(this, v);
+                v.setOnClickListener(this);
             }
 
             public void setTitle(final String title) {
@@ -162,14 +163,11 @@ public class ConferenceSessionListActivity extends InjectableActionBarActivity i
                 setTime(conferenceSessionData.getStartDttm());
                 setTitle(conferenceSessionData.getName());
                 setRoom("112E"); //TODO -- set to real value once room data is available
+            }
 
-                final long sessionId = conferenceSessionData.getId();
-                itemView.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View view) {
-                        launchEventDetailActivity(sessionId);
-                    }
-                });
+            @Override
+            public void onClick(View v) {
+                launchEventDetailActivity(conferenceSessionData.getId());
             }
         }
     }

--- a/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceSessionListActivity.java
+++ b/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceSessionListActivity.java
@@ -39,23 +39,12 @@ public class ConferenceSessionListActivity extends InjectableActionBarActivity i
     RecyclerView mRecyclerView;
 
     private ConferenceSessionsAdapter mAdapter;
-    private RecyclerView.LayoutManager mLayoutManager;
     private ConferenceSessionListActivityPresenter presenter = null;
-    private Integer conferenceId;
+    private Long conferenceId;
 
     @Override
     public void populateConferenceSessions(List<ConferenceSessionData> conferenceSessions) {
         mAdapter = new ConferenceSessionsAdapter(conferenceSessions);
-        mAdapter.setOnClickListener(new View.OnClickListener(){
-            @Override
-            public void onClick(View view) {
-                Timber.d(String.format("View Clicked: %s", view.getTag()));
-
-                Intent eventDetailIntent = new Intent(view.getContext(), EventDetailActivity.class);
-                eventDetailIntent.putExtra("id", (Long)view.getTag());
-                startActivity(eventDetailIntent);
-            }
-        });
         mRecyclerView.setAdapter(mAdapter);
     }
 
@@ -69,12 +58,10 @@ public class ConferenceSessionListActivity extends InjectableActionBarActivity i
         ButterKnife.inject(this);
 
         mRecyclerView.setHasFixedSize(true);
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
 
-        mLayoutManager = new LinearLayoutManager(this);
-        mRecyclerView.setLayoutManager(mLayoutManager);
-
-        conferenceId = getIntent().getExtras().getInt("id");
-        presenter = new ConferenceSessionListActivityPresenter(this, conferenceController, Long.valueOf(conferenceId));
+        conferenceId = getIntent().getExtras().getLong("id");
+        presenter = new ConferenceSessionListActivityPresenter(this, conferenceController, conferenceId);
         presenter.initialize();
     }
 
@@ -95,13 +82,20 @@ public class ConferenceSessionListActivity extends InjectableActionBarActivity i
         presenter.onDestroy();
     }
 
+    private void launchEventDetailActivity(long sessionId) {
+        Timber.d(String.format("Session Selected: %s", sessionId));
+
+        Intent eventDetailIntent = new Intent(this, EventDetailActivity.class);
+        eventDetailIntent.putExtra("id", sessionId);
+        startActivity(eventDetailIntent);
+    }
+
     public class ConferenceSessionsAdapter extends RecyclerView.Adapter<ConferenceSessionsAdapter.ViewHolder> {
         private final List<ConferenceSessionData> conferenceSessions;
-        private View.OnClickListener onClickListener;
 
         public class ViewHolder extends RecyclerView.ViewHolder {
             private final SimpleDateFormat DAY_FORMATTER = new SimpleDateFormat("EEEE, MMMM dd, yyyy", Locale.US);
-            private final SimpleDateFormat TIME_FORMATTER = new SimpleDateFormat("h:mm a");
+            private final SimpleDateFormat TIME_FORMATTER = new SimpleDateFormat("h:mm a", Locale.US);
 
             @InjectView(R.id.day) public TextView dayView;
             @InjectView(R.id.time) public TextView timeView;
@@ -112,10 +106,6 @@ public class ConferenceSessionListActivity extends InjectableActionBarActivity i
             public ViewHolder(View v) {
                 super(v);
                 ButterKnife.inject(this, v);
-            }
-
-            public void setTag(Object tag) {
-                super.itemView.setTag(tag);
             }
 
             public void setTitle(final String title) {
@@ -133,10 +123,6 @@ public class ConferenceSessionListActivity extends InjectableActionBarActivity i
             public void setRoom(final String room) {
                 this.roomView.setText(room);
             }
-
-            public void setOnClickListener(View.OnClickListener onClickListener) {
-                super.itemView.setOnClickListener(onClickListener);
-            }
         }
 
         public ConferenceSessionsAdapter(List<ConferenceSessionData> conferenceSessions) {
@@ -153,12 +139,23 @@ public class ConferenceSessionListActivity extends InjectableActionBarActivity i
 
         @Override
         public void onBindViewHolder(ConferenceSessionsAdapter.ViewHolder holder, int position) {
-            holder.setTag(getItem(position).getId());
             holder.setDay(getItem(position).getStartDttm());
             holder.setTime(getItem(position).getStartDttm());
             holder.setTitle(getItem(position).getName());
             holder.setRoom("112E"); //TODO -- set to real value once room data is available
-            holder.setOnClickListener(this.onClickListener);
+
+            final long sessionId = getItemId(position);
+            holder.itemView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    launchEventDetailActivity(sessionId);
+                }
+            });
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return getItem(position).getId();
         }
 
         @Override
@@ -168,10 +165,6 @@ public class ConferenceSessionListActivity extends InjectableActionBarActivity i
 
         public ConferenceSessionData getItem(int position) {
             return conferenceSessions.get(position);
-        }
-
-        public void setOnClickListener(View.OnClickListener onClickListener) {
-            this.onClickListener = onClickListener;
         }
     }
 }

--- a/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceSessionListActivity.java
+++ b/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceSessionListActivity.java
@@ -93,6 +93,37 @@ public class ConferenceSessionListActivity extends InjectableActionBarActivity i
     public class ConferenceSessionsAdapter extends RecyclerView.Adapter<ConferenceSessionsAdapter.ViewHolder> {
         private final List<ConferenceSessionData> conferenceSessions;
 
+        public ConferenceSessionsAdapter(List<ConferenceSessionData> conferenceSessions) {
+            this.conferenceSessions = conferenceSessions;
+        }
+
+        @Override
+        public ConferenceSessionsAdapter.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+            View v = LayoutInflater.from(parent.getContext())
+                    .inflate(R.layout.list_view_item, parent, false);
+
+            return new ViewHolder(v);
+        }
+
+        @Override
+        public void onBindViewHolder(ConferenceSessionsAdapter.ViewHolder holder, int position) {
+            holder.setConferenceSessionData(getItem(position));
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return getItem(position).getId();
+        }
+
+        @Override
+        public int getItemCount() {
+            return conferenceSessions.size();
+        }
+
+        public ConferenceSessionData getItem(int position) {
+            return conferenceSessions.get(position);
+        }
+
         public class ViewHolder extends RecyclerView.ViewHolder {
             private final SimpleDateFormat DAY_FORMATTER = new SimpleDateFormat("EEEE, MMMM dd, yyyy", Locale.US);
             private final SimpleDateFormat TIME_FORMATTER = new SimpleDateFormat("h:mm a", Locale.US);
@@ -101,6 +132,7 @@ public class ConferenceSessionListActivity extends InjectableActionBarActivity i
             @InjectView(R.id.time) public TextView timeView;
             @InjectView(R.id.title) public TextView titleView;
             @InjectView(R.id.room) public TextView roomView;
+            private ConferenceSessionData conferenceSessionData;
 
             // each data item is just a string in this case
             public ViewHolder(View v) {
@@ -123,48 +155,22 @@ public class ConferenceSessionListActivity extends InjectableActionBarActivity i
             public void setRoom(final String room) {
                 this.roomView.setText(room);
             }
-        }
 
-        public ConferenceSessionsAdapter(List<ConferenceSessionData> conferenceSessions) {
-            this.conferenceSessions = conferenceSessions;
-        }
+            public void setConferenceSessionData(ConferenceSessionData conferenceSessionData) {
+                this.conferenceSessionData = conferenceSessionData;
+                setDay(conferenceSessionData.getStartDttm());
+                setTime(conferenceSessionData.getStartDttm());
+                setTitle(conferenceSessionData.getName());
+                setRoom("112E"); //TODO -- set to real value once room data is available
 
-        @Override
-        public ConferenceSessionsAdapter.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-            View v = LayoutInflater.from(parent.getContext())
-                    .inflate(R.layout.list_view_item, parent, false);
-
-            return new ViewHolder(v);
-        }
-
-        @Override
-        public void onBindViewHolder(ConferenceSessionsAdapter.ViewHolder holder, int position) {
-            holder.setDay(getItem(position).getStartDttm());
-            holder.setTime(getItem(position).getStartDttm());
-            holder.setTitle(getItem(position).getName());
-            holder.setRoom("112E"); //TODO -- set to real value once room data is available
-
-            final long sessionId = getItemId(position);
-            holder.itemView.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    launchEventDetailActivity(sessionId);
-                }
-            });
-        }
-
-        @Override
-        public long getItemId(int position) {
-            return getItem(position).getId();
-        }
-
-        @Override
-        public int getItemCount() {
-            return conferenceSessions.size();
-        }
-
-        public ConferenceSessionData getItem(int position) {
-            return conferenceSessions.get(position);
+                final long sessionId = conferenceSessionData.getId();
+                itemView.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        launchEventDetailActivity(sessionId);
+                    }
+                });
+            }
         }
     }
 }

--- a/Conference-Android/app/src/main/res/layout/conference_list_view_item.xml
+++ b/Conference-Android/app/src/main/res/layout/conference_list_view_item.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent" android:layout_height="match_parent" android:clickable="true">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:focusable="true"
+    android:clickable="true">
 
     <TextView
         android:id="@+id/name"
@@ -8,10 +11,9 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
         android:layout_marginLeft="5dp"
-        android:layout_toLeftOf="@+id/scheduled"
+        android:layout_marginRight="5dp"
         android:text="Volley"
         android:textSize="18sp"
-        android:clickable="true"
         />
 
 </LinearLayout>


### PR DESCRIPTION
Turns out the problem with click was because the TextView had `clickable=true` set on it, which intercepted clicks before the parent item.

Additionally, I decided it would be better for the adapter to have the `onClick` logic inside it for a number of reasons. Mainly, if we add more listeners to a view, we would need to add new properties for each one. We would also need to rebind all the views if you were to change the `OnClickListener` on the adapter, and I just don't see that happening.

I also fixed a couple other warnings I found in the activities and implemented the other view holder to use butterknife.
