### PR TITLE
Issue #57.  The SplashActivity will now transition directly to the Confe...

### DIFF
--- a/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceDetailActivity.java
+++ b/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceDetailActivity.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 import butterknife.ButterKnife;
 import butterknife.InjectView;
 import butterknife.OnClick;
+import timber.log.Timber;
 
 public class ConferenceDetailActivity extends InjectableActionBarActivity implements IConferenceDetailActivity {
 

--- a/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceDetailActivity.java
+++ b/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceDetailActivity.java
@@ -45,9 +45,6 @@ public class ConferenceDetailActivity extends InjectableActionBarActivity implem
     @InjectView(R.id.txtConferenceFullDesc)
     TextView txtConferenceFullDesc;
 
-    @InjectView(R.id.txtContactText)
-    TextView txtContactText;
-
     @Inject
     IConferenceDetailActivityPresenter presenter;
 
@@ -115,6 +112,5 @@ public class ConferenceDetailActivity extends InjectableActionBarActivity implem
         txtConferenceName.setText(conferenceDetailViewModel.getName());
         txtConferenceDate.setText(conferenceDetailViewModel.getDateInformation());
         txtConferenceFullDesc.setText(conferenceDetailViewModel.getFullDescription());
-        txtContactText.setText(conferenceDetailViewModel.getConferenceContactPerson());
     }
 }

--- a/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceDetailActivity.java
+++ b/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceDetailActivity.java
@@ -74,6 +74,8 @@ public class ConferenceDetailActivity extends InjectableActionBarActivity implem
             public void onClick(View v) {
                 Intent conferenceSessionListIntent = new Intent(imgConfMap.getContext(), ConferenceSessionListActivity.class);
                 conferenceSessionListIntent.putExtra("id", conferenceId);
+                conferenceSessionListIntent.putExtra("conferenceName", txtConferenceName.getText());
+                conferenceSessionListIntent.putExtra("conferenceDate", txtConferenceDate.getText());
                 startActivity(conferenceSessionListIntent);
             }
         });

--- a/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceSessionDetailActivity.java
+++ b/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceSessionDetailActivity.java
@@ -64,6 +64,8 @@ public class ConferenceSessionDetailActivity extends InjectableActionBarActivity
         mPresenterView.setHasFixedSize(true);
         mPresenterView.setLayoutManager(new LinearLayoutManager(this));
 
+        super.setTitle("Session Details");
+
         Long eventId = getIntent().getLongExtra("id", 0);
         presenter.initialize(eventId);
     }

--- a/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceSessionListActivity.java
+++ b/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/ConferenceSessionListActivity.java
@@ -6,11 +6,15 @@ import android.support.v4.app.NavUtils;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.MenuItem;
+import android.widget.ImageView;
+import android.widget.TextView;
 
 import com.sagetech.conference_android.app.R;
+import com.sagetech.conference_android.app.model.ConferenceData;
 import com.sagetech.conference_android.app.ui.adapters.ConferenceSessionListAdapter;
 import com.sagetech.conference_android.app.ui.presenter.IConferenceSessionActivity;
 import com.sagetech.conference_android.app.ui.presenter.IConferenceSessionListPresenter;
+import com.sagetech.conference_android.app.ui.viewModel.ConferenceDetailViewModel;
 import com.sagetech.conference_android.app.ui.viewModel.ConferenceSessionViewModel;
 import com.sagetech.conference_android.app.util.module.ConferenceSessionListModule;
 
@@ -34,6 +38,12 @@ public class ConferenceSessionListActivity extends InjectableActionBarActivity i
     @InjectView(R.id.confView)
     RecyclerView mRecyclerView;
 
+    @InjectView(R.id.txtConferenceName)
+    TextView txtConferenceName;
+
+    @InjectView(R.id.txtConferenceDate)
+    TextView txtConferenceDate;
+
     private ConferenceSessionListAdapter mAdapter;
 
     @Override
@@ -47,6 +57,11 @@ public class ConferenceSessionListActivity extends InjectableActionBarActivity i
 
         mRecyclerView.setHasFixedSize(true);
         mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+
+        setTitle("Event Sessions");
+
+        this.txtConferenceDate.setText(getIntent().getStringExtra("conferenceDate"));
+        this.txtConferenceName.setText(getIntent().getStringExtra("conferenceName"));
 
         Long conferenceId = getIntent().getLongExtra("id", 0);
         presenter.initialize(conferenceId);

--- a/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/SplashActivity.java
+++ b/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/activities/SplashActivity.java
@@ -7,15 +7,12 @@ import android.support.v7.app.ActionBarActivity;
 
 import com.sagetech.conference_android.app.R;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import rx.Observable;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.android.app.AppObservable;
-import rx.android.schedulers.AndroidSchedulers;
-import rx.schedulers.Schedulers;
 import timber.log.Timber;
 
 public class SplashActivity extends ActionBarActivity {
@@ -37,7 +34,8 @@ public class SplashActivity extends ActionBarActivity {
                     @Override
                     public void onCompleted() {
                         Timber.i("onCompleted");
-                        Intent intent = new Intent(getApplicationContext(), ConferenceListActivity.class);
+                        Intent intent = new Intent(getApplicationContext(), ConferenceDetailActivity.class);
+                        intent.putExtra("id", Long.valueOf(getString(R.string.google_io_conference_id)));
                         startActivity(intent);
                         finish();
                     }

--- a/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/viewModel/ConferenceDetailViewModel.java
+++ b/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/viewModel/ConferenceDetailViewModel.java
@@ -4,8 +4,11 @@ import android.text.format.DateFormat;
 
 import com.sagetech.conference_android.app.model.ConferenceData;
 
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+
+import timber.log.Timber;
 
 /**
  * Created by carlushenry on 4/2/15.
@@ -53,8 +56,8 @@ public class ConferenceDetailViewModel {
 
             // May 31 - Jun 02 2015
             return String.format("%s %s - %s %s %s", startMonth, startDay, endMonth, endDay, year);
-        } catch(Exception ex) {
-            // Do nothing, just return the default
+        } catch(ParseException e) {
+            Timber.e("Parse exception while attempting to parse date.", e);
         }
 
         return null;

--- a/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/viewModel/ConferenceDetailViewModel.java
+++ b/Conference-Android/app/src/main/java/com/sagetech/conference_android/app/ui/viewModel/ConferenceDetailViewModel.java
@@ -1,7 +1,11 @@
 package com.sagetech.conference_android.app.ui.viewModel;
 
-import com.sagetech.conference_android.app.R;
+import android.text.format.DateFormat;
+
 import com.sagetech.conference_android.app.model.ConferenceData;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 /**
  * Created by carlushenry on 4/2/15.
@@ -9,6 +13,7 @@ import com.sagetech.conference_android.app.model.ConferenceData;
 public class ConferenceDetailViewModel {
 
     private final ConferenceData confData;
+    private final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 
     public ConferenceDetailViewModel(ConferenceData confData) {
         this.confData = confData;
@@ -19,7 +24,40 @@ public class ConferenceDetailViewModel {
     }
 
     public String getDateInformation() {
-        return String.format("%s %d - %d %d", "May", 23, 24, 2015);
+        String startDate = confData.getStartDate();
+        String endDate = confData.getEndDate();
+
+        if(startDate == null || startDate.isEmpty() || endDate == null || endDate.isEmpty()) {
+            return null;
+        }
+
+        try {
+            Date start = sdf.parse(startDate);
+            Date end = sdf.parse(endDate);
+
+            String startMonth = (String) DateFormat.format("MMMM", start);
+            String startDay = (String) DateFormat.format("dd", start);
+            String endMonth = (String) DateFormat.format("MMMM", end);
+            String endDay = (String) DateFormat.format("dd", end);
+            String year = (String) DateFormat.format("yyyy", end);
+
+            if(startMonth != null && startMonth.equals(endMonth)) {
+                if(startDay != null && startDay.equals(endDay)) {
+                    // May 19 2015
+                    return String.format("%s %s %s", startMonth, startDay, year);
+                }
+
+                // May 24 - 25 2015
+                return String.format("%s %s - %s %s", startMonth, startDay, endDay, year);
+            }
+
+            // May 31 - Jun 02 2015
+            return String.format("%s %s - %s %s %s", startMonth, startDay, endMonth, endDay, year);
+        } catch(Exception ex) {
+            // Do nothing, just return the default
+        }
+
+        return null;
     }
 
     public String getFullDescription() {

--- a/Conference-Android/app/src/main/res/layout/actionbar_conference_detail.xml
+++ b/Conference-Android/app/src/main/res/layout/actionbar_conference_detail.xml
@@ -13,7 +13,7 @@
             android:layout_height="wrap_content"
             android:textAppearance="?android:attr/textAppearanceMedium"
             android:text="Event Details"
-            android:id="@+id/txtEventetails"
+            android:id="@+id/txtEventDetails"
             android:layout_margin="15dp"
             android:textColor="@android:color/white" />
     </LinearLayout>

--- a/Conference-Android/app/src/main/res/layout/conference_detail.xml
+++ b/Conference-Android/app/src/main/res/layout/conference_detail.xml
@@ -105,21 +105,6 @@
                     android:text="Image 6" />
             </GridLayout>
 
-            <TextView
-                android:id="@+id/txtQuestionsText"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/conference_detail_marginLeft"
-                android:layout_marginTop="@dimen/conference_detail_marginTop"
-                tools:text="Questions?"
-                android:text="Questions?" />
-
-            <TextView
-                android:id="@+id/txtContactText"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_margin="@dimen/conference_detail_marginLeft"
-                tools:text="Contact: Mahmoud Ahmadinejad"/>
         </LinearLayout>
     </ScrollView>
 

--- a/Conference-Android/app/src/main/res/values/strings.xml
+++ b/Conference-Android/app/src/main/res/values/strings.xml
@@ -10,5 +10,6 @@
     <string name="title_activity_conference_sessions">ConferenceSessionsActivity</string>
     <string name="title_activity_conference_detail">ConferenceDetailActivity</string>
     <string name="transition_conference_image">transition_conference_image</string>
+    <string name="google_io_conference_id">1</string>
 
 </resources>


### PR DESCRIPTION
...renceDetailActivity for google_io_conference_id defined in the strings.xml.

@jonasrob .... This task is working, but please take a look at it to see if what I did makes sense.  In order to start an activity for a specific conference, we need to store the id of that conference somewhere.  The most logical place seemed like a resource folder.  I ended up adding it to the strings.xml, even though that seems like it's probably meant for i18n.  The other option was hard-coding it in the activity or maybe adding it to build.grade as a buildConfigField.  I'll leave it up to you.  Regardless, we will need to update it once we actually know the conference id for I/O 2015.
